### PR TITLE
chore: add MONGO_DATABASE override, bump deps, drop unused mysql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.17.0</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -120,17 +120,12 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.2.1</version>
+            <version>5.4.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.hkarthik7</groupId>
             <artifactId>azd</artifactId>
             <version>5.0.6</version>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.33</version>
         </dependency>
         <dependency>
             <groupId>com.github.Remote-Falcon</groupId>
@@ -189,7 +184,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.9.4</version>
+                <version>1.11.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-collections</groupId>

--- a/src/main/java/com/remotefalcon/external/api/Application.java
+++ b/src/main/java/com/remotefalcon/external/api/Application.java
@@ -5,14 +5,13 @@ import org.dozer.DozerBeanMapper;
 import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class })
+@SpringBootApplication
 @ImportRuntimeHints(DozerRuntimeHints.class)
 @EnableAspectJAutoProxy
 @EnableMongoRepositories

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ spring:
     name: remote-falcon-external-api
   main:
     web-application-type: servlet
+  data:
+    mongodb:
+      database: ${MONGO_DATABASE:remote-falcon}
   jpa:
     hibernate:
       naming:


### PR DESCRIPTION
## Summary
- `spring.data.mongodb.database` now resolves from `${MONGO_DATABASE:remote-falcon}`. Same fix as the parallel PR on control-panel.
- Closes 4 Dependabot alerts:
  - `commons-lang3` 3.17.0 → 3.18.0 *(medium)*
  - `commons-beanutils` 1.9.4 → 1.11.0 *(high)*
  - `poi-ooxml` 5.2.1 → 5.4.0 *(medium)*
  - `mysql-connector-java` 8.0.33 → **removed** *(high)* — repo never had any JDBC code; the only reason it was on the classpath was the `DataSourceAutoConfiguration` exclusion in `Application.java`, which is also removed now that the dep is gone.

## Test plan
- [ ] `mvn -DskipTests package` builds clean.
- [ ] Pod starts without `DataSourceAutoConfiguration` excluded (no JDBC driver on classpath, so Spring Boot won't try to auto-wire a DataSource).
- [ ] All 4 Dependabot alerts close out.
- [ ] No regression in the GraphQL surface (the only thing this service exposes).