### PR TITLE
fix: restore DataSourceAutoConfiguration exclude

### DIFF
--- a/src/main/java/com/remotefalcon/external/api/Application.java
+++ b/src/main/java/com/remotefalcon/external/api/Application.java
@@ -5,13 +5,14 @@ import org.dozer.DozerBeanMapper;
 import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 @ImportRuntimeHints(DozerRuntimeHints.class)
 @EnableAspectJAutoProxy
 @EnableMongoRepositories


### PR DESCRIPTION
## Summary
Hotfix for the failed external-api deploy from PR #4.

The `@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})` exclusion was removed in #4 under the assumption it was only there for the unused `mysql-connector-java` dep. In fact it was *also* protecting against Spring Boot's JPA auto-config — `spring-boot-starter-data-jpa` is still pulled in (transitively or directly) and tries to wire up an `entityManagerFactory` at startup, which then requires a DataSource that doesn't exist:

```
APPLICATION FAILED TO START

Description:
Failed to configure a DataSource: 'url' attribute is not specified
and no embedded datasource could be configured.

Reason: Failed to determine a suitable driver class
```

This restores the exclude (and its import). The `mysql-connector-java` removal from #4 is correct and stays — the dep was genuinely unused.

## Test plan
- [ ] After merge + deploy: pod starts cleanly, no "Failed to determine a suitable driver class" error
- [ ] `kubectl rollout status` completes successfully
- [ ] GraphQL endpoint responds normally

## Follow-up
The pom still pulls in JPA somewhere even though this service uses only MongoDB. Worth a separate audit to see if `spring-boot-starter-data-jpa` (or whatever's pulling Hibernate in) can actually be removed entirely — at which point the exclude wouldn't be needed at all. Out of scope for this hotfix.